### PR TITLE
log handler and spreadsheet backend refactor

### DIFF
--- a/handler/addLogline.js
+++ b/handler/addLogline.js
@@ -1,0 +1,9 @@
+const Log = require('../lib/Log')
+const log = new Log()
+
+module.exports = async (req, res, next) => {
+  const rfid = req.body
+  await log.add(rfid)
+  res.setHeader('Content-Type', 'text/plain')
+  res.send(200)
+}

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const auth = require('./middleware/auth')
 
 const getWhitelist = require('./handler/getWhitelist')
 const addWhitelist = require('./handler/addWhitelist')
+const addLogline = require('./handler/addLogline')
 
 // heroku sets port
 const PORT = process.env.PORT || 3000
@@ -14,15 +15,8 @@ const app = express()
 app.use(auth)
 app.use(bodyParser.text())
 
-// TODO: error handling middleware that works with async handler?
-// app.use(function (err, req, res, next) {
-//   console.error(err.stack)
-//   res.status(500).send('Woops, something went wrong')
-// })
-
 app.get('/whitelist', asyncHandler(getWhitelist))
 app.post('/whitelist', asyncHandler(addWhitelist))
-
-app.post('/log', (req, res) => res.send('TODO'))
+app.post('/log', asyncHandler(addLogline))
 
 app.listen(PORT, () => console.log(`Listening on port ${PORT}`))

--- a/lib/Log.js
+++ b/lib/Log.js
@@ -1,0 +1,25 @@
+const SpreadSheetBackend = require('./SpreadSheetBackend')
+
+class Log extends SpreadSheetBackend {
+  constructor () {
+    super('log')
+  }
+
+  add (rfid) {
+    return this.request((resolve, reject, worksheet) => {
+      const newRow = { rfid, timestamp: new Date() }
+      console.log('Adding new row: ', newRow)
+      worksheet.addRow(newRow, (err, row) => {
+        if (err) {
+          console.error('Error adding row:', err)
+          reject(err)
+        } else {
+          console.log('Row added: ', newRow)
+          resolve(row)
+        }
+      })
+    })
+  }
+}
+
+module.exports = Log

--- a/lib/SpreadSheetBackend.js
+++ b/lib/SpreadSheetBackend.js
@@ -1,0 +1,36 @@
+const GoogleSpreadsheet = require('google-spreadsheet')
+
+const serviceAccountCredentials = process.env.NODE_ENV === 'production'
+  ? JSON.parse(process.env.DOOR24_KEY) // is a string, needs to be parsed to JS
+  : require(process.env.KEY_FILE_PATH)
+
+const { SHEET_ID } = process.env
+
+class SpreadSheetBackend {
+  constructor (worksheetName) {
+    this.spreadsheet = new GoogleSpreadsheet(SHEET_ID)
+    this.worksheetName = worksheetName
+    this.credentials = serviceAccountCredentials
+  }
+
+  request (callback) {
+    console.log('Authenticating with Google Sheets API')
+    return new Promise((resolve, reject) => {
+      this.spreadsheet.useServiceAccountAuth(this.credentials, () => {
+        // We need sheet info to find the worksheet
+        console.log('Fetching sheet info')
+        this.spreadsheet.getInfo((err, info) => {
+          if (err) {
+            console.error('Error fething sheet:', err)
+            reject(err)
+          } else {
+            const worksheet = info.worksheets.find(sheet => sheet.title === this.worksheetName)
+            return callback(resolve, reject, worksheet)
+          }
+        })
+      })
+    })
+  }
+}
+
+module.exports = SpreadSheetBackend

--- a/lib/Whitelist.js
+++ b/lib/Whitelist.js
@@ -1,76 +1,36 @@
-const GoogleSpreadsheet = require('google-spreadsheet')
+const SpreadSheetBackend = require('./SpreadSheetBackend')
 
-const serviceAccountCredentials = process.env.NODE_ENV === 'production'
-  ? JSON.parse(process.env.DOOR24_KEY) // is a string, needs to be parsed to JS
-  : require(process.env.KEY_FILE_PATH)
-
-const { SHEET_ID } = process.env
-const WHITELIST_WORKSHEET_NAME = 'whitelist'
-
-class Whitelist {
+class Whitelist extends SpreadSheetBackend {
   constructor () {
-    this.spreadsheet = new GoogleSpreadsheet(SHEET_ID)
+    super('whitelist')
   }
 
   async add (rfid) {
-    return new Promise((resolve, reject) => {
-      this.spreadsheet.useServiceAccountAuth(serviceAccountCredentials, () => {
-        // We need sheet info to find the worksheet index
-        console.log('Fetching sheet info')
-        this.spreadsheet.getInfo((err, info) => {
-          if (err) {
-            console.error('Error fething sheet:', err)
-            reject(err)
-          } else {
-            const newRow = { rfid }
-
-            let worksheetIndex
-            for (let i = 0; i < info.worksheets.length; i++) {
-              if (info.worksheets[i].title === WHITELIST_WORKSHEET_NAME) {
-                worksheetIndex = i + 1 // worksheet index starts at 1
-                break
-              }
-            }
-
-            console.log('Adding new row: ', newRow)
-            this.spreadsheet.addRow(worksheetIndex, newRow, (err, row) => {
-              if (err) {
-                console.error('Error adding row:', err)
-                reject(err)
-              } else {
-                console.log('Row added: ', newRow)
-                resolve(row)
-              }
-            })
-          }
-        })
+    return this.request((resolve, reject, worksheet) => {
+      const newRow = { rfid }
+      console.log('Adding new row: ', newRow)
+      worksheet.addRow(newRow, (err, row) => {
+        if (err) {
+          console.error('Error adding row:', err)
+          reject(err)
+        } else {
+          console.log('Row added: ', newRow)
+          resolve(row)
+        }
       })
     })
   }
 
   async getAll () {
-    return new Promise((resolve, reject) => {
-      console.log('Authenticating with Google Sheets API')
-      this.spreadsheet.useServiceAccountAuth(serviceAccountCredentials, () => {
-        console.log('Fetching sheet')
-        this.spreadsheet.getInfo((err, info) => {
-          if (err) {
-            console.error('Error fething sheet:', err)
-            reject(err)
-          } else {
-            const sheet = info.worksheets.find(sheet => sheet.title === WHITELIST_WORKSHEET_NAME)
-            console.log('Fetching rows')
-            sheet.getRows({}, (err, rows) => {
-              if (err) {
-                console.error('Error getting rows:', err)
-                reject(err)
-              } else {
-                const whitelistData = rows.map(row => row.rfid).join(',')
-                resolve(whitelistData)
-              }
-            })
-          }
-        })
+    return this.request((resolve, reject, worksheet) => {
+      worksheet.getRows({}, (err, rows) => {
+        if (err) {
+          console.error('Error getting rows:', err)
+          reject(err)
+        } else {
+          const whitelistData = rows.map(row => row.rfid).join(',')
+          resolve(whitelistData)
+        }
       })
     })
   }


### PR DESCRIPTION
@h5d now you can POSt to /log in the same way as posting to /whitelist, and it'll add a log entry

example:
```c++
client.println("POST /log HTTP/1.1");
```